### PR TITLE
[JEP-200] Save charset names, not actual Charset objects

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,1 @@
+buildPlugin()

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,8 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>1.399</version>
+        <version>3.2</version>
+        <relativePath />
     </parent>
 
     <artifactId>project-description-setter</artifactId>
@@ -40,7 +41,8 @@
     <url>http://wiki.jenkins-ci.org/display/JENKINS/Project+Description+Setter+Plugin</url>
 
     <properties>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <jenkins.version>1.625.3</jenkins.version>
+        <java.level>7</java.level>
     </properties>
     
     <licenses>
@@ -64,6 +66,11 @@
             <artifactId>token-macro</artifactId>
             <version>1.5.1</version>
         </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>matrix-project</artifactId>
+            <version>1.0</version>
+        </dependency>
     </dependencies>
 
     <scm>
@@ -76,24 +83,6 @@
         <system>JIRA</system>
         <url>http://issues.jenkins-ci.org/</url>
     </issueManagement>
-    
-    <distributionManagement>
-        <repository>
-            <id>maven.jenkins-ci.org</id>
-            <url>http://maven.jenkins-ci.org:8081/content/repositories/releases/</url>
-        </repository>
-    </distributionManagement>
-        
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.jenkins-ci.tools</groupId>
-                <artifactId>maven-hpi-plugin</artifactId>
-                <version>1.67</version>
-                <extensions>true</extensions>
-            </plugin>
-        </plugins>
-    </build>
     
 </project>  
   

--- a/pom.xml
+++ b/pom.xml
@@ -84,7 +84,17 @@
         <url>http://issues.jenkins-ci.org/</url>
     </issueManagement>
     
+    <repositories>
+        <repository>
+            <id>repo.jenkins-ci.org</id>
+            <url>https://repo.jenkins-ci.org/public/</url>
+        </repository>
+    </repositories>
+    <pluginRepositories>
+        <pluginRepository>
+            <id>repo.jenkins-ci.org</id>
+            <url>https://repo.jenkins-ci.org/public/</url>
+        </pluginRepository>
+    </pluginRepositories>
+
 </project>  
-  
-
-

--- a/src/main/java/org/jenkinsCi/plugins/projectDescriptionSetter/DescriptionSetterWrapper.java
+++ b/src/main/java/org/jenkinsCi/plugins/projectDescriptionSetter/DescriptionSetterWrapper.java
@@ -146,7 +146,7 @@ public class DescriptionSetterWrapper extends BuildWrapper implements MatrixAggr
             reader = new InputStreamReader(new BufferedInputStream(in), Charset.forName(charsetName));
             writer = new StringWriter();
             IOUtils.copy(reader, writer);
-        } catch (IOException ioe) {
+        } catch (IOException | InterruptedException ioe) {
             IOUtils.closeQuietly(reader);
             IOUtils.closeQuietly(in);
             IOUtils.closeQuietly(writer);

--- a/src/main/java/org/jenkinsCi/plugins/projectDescriptionSetter/DescriptionSetterWrapper.java
+++ b/src/main/java/org/jenkinsCi/plugins/projectDescriptionSetter/DescriptionSetterWrapper.java
@@ -49,19 +49,21 @@ import java.nio.charset.Charset;
 
 public class DescriptionSetterWrapper extends BuildWrapper implements MatrixAggregatable {
 
-    final Charset charset;
+    @Deprecated
+    transient Charset charset;
+    String charsetName;
     final String projectDescriptionFilename;
     final boolean disableTokens;
 
     @DataBoundConstructor
     public DescriptionSetterWrapper(final String charset, final String projectDescriptionFilename, final boolean disableTokens) {
-        this.charset = Charset.forName(charset);
+        this.charsetName = charset;
         this.projectDescriptionFilename = projectDescriptionFilename;
         this.disableTokens = disableTokens;
     }
 
     public String getCharset() {
-        return charset.displayName();
+        return charsetName;
     }
 
     public String getProjectDescriptionFilename() {
@@ -70,6 +72,13 @@ public class DescriptionSetterWrapper extends BuildWrapper implements MatrixAggr
 
     public boolean isDisableTokens() {
         return disableTokens;
+    }
+
+    private Object readResolve() {
+        if (charset != null) {
+            charsetName = charset.name();
+        }
+        return this;
     }
 
     @Override
@@ -134,7 +143,7 @@ public class DescriptionSetterWrapper extends BuildWrapper implements MatrixAggr
         StringWriter writer = null;
         try {
             in = projectDescriptionFile.read();
-            reader = new InputStreamReader(new BufferedInputStream(in), charset);
+            reader = new InputStreamReader(new BufferedInputStream(in), Charset.forName(charsetName));
             writer = new StringWriter();
             IOUtils.copy(reader, writer);
         } catch (IOException ioe) {

--- a/src/main/java/org/jenkinsCi/plugins/projectDescriptionSetter/DescriptionSetterWrapper.java
+++ b/src/main/java/org/jenkinsCi/plugins/projectDescriptionSetter/DescriptionSetterWrapper.java
@@ -33,7 +33,6 @@ import hudson.matrix.MatrixBuild;
 import hudson.matrix.MatrixRun;
 import hudson.model.AbstractBuild;
 import hudson.model.BuildListener;
-import hudson.model.Hudson;
 import hudson.tasks.BuildWrapper;
 import org.apache.commons.io.IOUtils;
 import org.jenkinsci.plugins.tokenmacro.MacroEvaluationException;
@@ -46,6 +45,7 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.StringWriter;
 import java.nio.charset.Charset;
+import jenkins.model.Jenkins;
 
 public class DescriptionSetterWrapper extends BuildWrapper implements MatrixAggregatable {
 
@@ -117,7 +117,11 @@ public class DescriptionSetterWrapper extends BuildWrapper implements MatrixAggr
         final String trimmed = Util.fixEmptyAndTrim(fileName);
         if (trimmed == null) return null;
         final String expandedFilename = expand(build, listener, fileName);
-        final FilePath projectDescriptionFile = build.getWorkspace().child(expandedFilename);
+        FilePath workspace = build.getWorkspace();
+        if (workspace == null) {
+            return null;
+        }
+        final FilePath projectDescriptionFile = workspace.child(expandedFilename);
         if (!projectDescriptionFile.exists()) {
             listener.getLogger().println(Messages.console_noFile(expandedFilename));
             return null;
@@ -160,7 +164,7 @@ public class DescriptionSetterWrapper extends BuildWrapper implements MatrixAggr
 
     @Override
     public DescriptionSetterWrapperDescriptor getDescriptor() {
-        return Hudson.getInstance().getDescriptorByType(DescriptionSetterWrapperDescriptor.class);
+        return Jenkins.getActiveInstance().getDescriptorByType(DescriptionSetterWrapperDescriptor.class);
     }
 
 }


### PR DESCRIPTION
See https://github.com/jenkinsci/jenkins/pull/3120. Note that

* `DescriptionSetterWrapperDescriptor` was already doing the right thing.
* The current getter is not right—should return `.name()`, not `.displayName()`.
* This patch does not address old saved settings, which would presumably block the wrapper from loading. You would need to resave the project _before_ updating Jenkins. Fixing that would be hard—would need a custom XStream `Converter`, I think.

@reviewbybees